### PR TITLE
Add giftwrapping as a separate line item when sending order to zipco

### DIFF
--- a/app/services/workarea/zipco/order.rb
+++ b/app/services/workarea/zipco/order.rb
@@ -101,7 +101,6 @@ module Workarea
               quantity: oi.quantity,
               type: "sku",
               reference: oi.id,
-              #image_uri: ProductImageUrl.product_image_url(oi.image, :detail),
               item_uri: ProductUrl.product_url(id: oi.product.to_param, host: Workarea.config.host)
             }
           end
@@ -123,6 +122,10 @@ module Workarea
             type: "shipping",
             reference: "#{order.id}-shipping",
           }
+
+          if gift_wrap_item.present?
+            items_array << gift_wrap_item
+          end
 
           items_array + discount_items + advanced_payment_discount_item
         end
@@ -163,6 +166,18 @@ module Workarea
 
         def confirm_url
           Storefront::Engine.routes.url_helpers.complete_zipco_url(host: Workarea.config.host)
+        end
+
+        def gift_wrap_item
+          adjustment = order.price_adjustments.detect { |pa| pa.description == 'Gift Wrapping' }
+          return unless adjustment.present?
+
+          {
+            name: "Gift Wrapping",
+            amount: adjustment.amount.to_f,
+            quantity: 1,
+            type: "sku"
+          }
         end
     end
   end

--- a/test/services/workarea/zipco/order_test.rb
+++ b/test/services/workarea/zipco/order_test.rb
@@ -37,6 +37,22 @@ module Workarea
         zipco_shipping = zipco_order[:shipping]
         assert(zipco_shipping.present?)
         assert(zipco_shipping[:address].present?)
+
+        item = order.items.first
+        item.adjust_pricing(
+          price: 'item',
+          quantity: 1,
+          description: "Gift Wrapping",
+          calculator: "Workarea::Pricing::Calculators::GiftWrappingCalculator",
+          amount: 5.to_m,
+          data: {}
+          )
+
+        order_hash = Workarea::Zipco::Order.new(order).to_h
+
+        gift_wrap_item = order_hash[:order][:items].detect { |i| i[:name] == "Gift Wrapping" }
+        assert(gift_wrap_item.present?)
+        assert_equal(5.0, gift_wrap_item[:amount])
       end
 
       private


### PR DESCRIPTION
Zipco API expects the unit price of the item, which does not include the gift wrapping charges. This causes an error when the cart is reconciled on zips end. 


ZIPCO-3
