### PR TITLE
Updates from certification testing

### DIFF
--- a/app/services/workarea/zipco/order.rb
+++ b/app/services/workarea/zipco/order.rb
@@ -95,12 +95,16 @@ module Workarea
         def items
           items_array = order.items.map do |oi|
 
+            url = ProductImageUrl.product_image_url(oi.image, :detail)
+            item_image = url.starts_with?("/") ? nil : url
+
             {
               name: oi.product.name,
               amount: oi.original_unit_price.to_f,
               quantity: oi.quantity,
               type: "sku",
               reference: oi.id,
+              image_uri: item_image,
               item_uri: ProductUrl.product_url(id: oi.product.to_param, host: Workarea.config.host)
             }
           end

--- a/config/initializers/workarea.rb
+++ b/config/initializers/workarea.rb
@@ -4,8 +4,8 @@ Workarea.configure do |config|
 
   config.zipco = ActiveSupport::Configurable::Configuration.new
   config.zipco.api_version = "2017-03-01"
-  config.zipco.api_timeout = 10
-  config.zipco.open_timeout = 10
+  config.zipco.api_timeout = 15
+  config.zipco.open_timeout = 15
 
   config.zipco.marketing_assets_key = nil
   config.zipco.marketing_assets_env = Rails.env.production? ? "production" : "sandbox"

--- a/lib/workarea/zipco.rb
+++ b/lib/workarea/zipco.rb
@@ -14,7 +14,7 @@ require "faraday"
 
 module Workarea
   module Zipco
-    ALLOWED_COUNTRIES = ["AU", "NZ"]
+    RETRY_ERROR_STATUSES = 500..599
 
     def self.credentials
       (Rails.application.secrets.zipco || {}).deep_symbolize_keys

--- a/lib/workarea/zipco/bogus_gateway.rb
+++ b/lib/workarea/zipco/bogus_gateway.rb
@@ -5,15 +5,19 @@ module Workarea
         Response.new(response(create_order_body))
       end
 
-      def capture(attrs)
+      def capture(attrs, request_id = nil)
         Response.new(response(capture_body))
       end
 
-      def authorize(attrs)
-        Response.new(response(capture_body))
+      def authorize(attrs, request_id = nil)
+        if attrs[:authority][:value] == "timeout_token"
+          Response.new(response(nil, 502))
+        else
+          Response.new(response(capture_body))
+        end
       end
 
-      def purchase(attrs)
+      def purchase(attrs, request_id = nil)
         Response.new(response(capture_body))
       end
 

--- a/lib/workarea/zipco/gateway.rb
+++ b/lib/workarea/zipco/gateway.rb
@@ -17,17 +17,18 @@ module Workarea
         Zipco::Response.new(response)
       end
 
-      def authorize(attrs)
+      def authorize(attrs, request_key = nil)
         response = connection.post do |req|
           req.url "merchant/v1/charges"
           req.body = attrs.to_json
+          req.headers["Idempotency-Key"] = request_key
         end
 
         Zipco::Response.new(response)
       end
       alias :purchase :authorize
 
-      def capture(charge_id, amount)
+      def capture(charge_id, amount, request_key = nil)
         body = {
           amount: amount.to_f
         }
@@ -35,12 +36,13 @@ module Workarea
         response = connection.post do |req|
           req.url "merchant/v1/charges/#{charge_id}/capture"
           req.body = body.to_json
+          req.headers["Idempotency-Key"] = request_key
         end
 
         Zipco::Response.new(response)
       end
 
-      def refund(charge_id, amount)
+      def refund(charge_id, amount, request_key = nil)
         reason = "Web Refund"
         body = {
           charge_id: charge_id,
@@ -51,6 +53,7 @@ module Workarea
         response = connection.post do |req|
           req.url "merchant/v1/refunds"
           req.body = body.to_json
+          req.headers["Idempotency-Key"] = request_key
         end
         Zipco::Response.new(response)
       end

--- a/lib/workarea/zipco/response.rb
+++ b/lib/workarea/zipco/response.rb
@@ -20,6 +20,10 @@ module Workarea
       def body
         @body ||= JSON.parse(@response.body)
       end
+
+      def status
+        @response.status
+      end
     end
   end
 end

--- a/test/models/workarea/payment/zipco_payment_integration_test.rb
+++ b/test/models/workarea/payment/zipco_payment_integration_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+module Workarea
+  class ZipcoPaymentIntegrationTest < Workarea::TestCase
+    def test_auth_capture
+      transaction = tender.build_transaction(action: 'authorize')
+      Payment::Purchase::Zipco.new(tender, transaction).complete!
+
+      assert(transaction.success?)
+      transaction.save!
+
+      assert(tender.token.present?)
+
+      capture = Payment::Capture.new(payment: payment)
+      capture.allocate_amounts!(total: 5.to_m)
+      assert(capture.valid?)
+      capture.complete!
+
+      capture_transaction = payment.transactions.detect(&:captures)
+      assert(capture_transaction.valid?)
+    end
+
+    def test_auth
+      transaction = tender.build_transaction(action: 'authorize')
+      Payment::Authorize::Zipco.new(tender, transaction).complete!
+      assert(transaction.success?, 'expected transaction to be successful')
+    end
+
+    def test_purchase
+      transaction = tender.build_transaction(action: 'purchase')
+      Payment::Purchase::Zipco.new(tender, transaction).complete!
+      assert(transaction.success?)
+    end
+
+    def test_timeout_auth
+      transaction = timeout_tender.build_transaction(action: 'authorize')
+      operation = Payment::Authorize::Zipco.new(timeout_tender, transaction)
+      operation.complete!
+      refute(transaction.success?, 'expected transaction to be a failure')
+    end
+
+    private
+
+      def payment
+        @payment ||=
+          begin
+            profile = create_payment_profile
+            create_payment(
+              profile_id: profile.id,
+              address: {
+                first_name: 'Ben',
+                last_name: 'Crouse',
+                street: '22 s. 3rd st.',
+                city: 'Philadelphia',
+                region: 'PA',
+                postal_code: '19106',
+                country: Country['US']
+              }
+            )
+          end
+      end
+
+      def tender
+        @tender ||=
+          begin
+            payment.set_address(first_name: 'Ben', last_name: 'Crouse')
+
+            payment.build_zipco(
+              token: '12345'
+            )
+
+            payment.zipco
+          end
+      end
+
+      def timeout_tender
+        @tender ||=
+          begin
+            payment.set_address(first_name: 'Ben', last_name: 'Crouse')
+
+            payment.build_zipco(
+              token: 'timeout_token'
+            )
+
+            payment.zipco
+          end
+      end
+  end
+end


### PR DESCRIPTION
Send image urls if the asset host is present. Send transactional
API calls with an idempotency key and retry if not successful.

no changelog

ZIPCO-2