### PR TITLE
Ruby 3.2+ Compatibility Updates

### DIFF
--- a/app/services/workarea/zipco/checkout.rb
+++ b/app/services/workarea/zipco/checkout.rb
@@ -17,7 +17,7 @@ module Workarea
         if result == "referred"
           order.set_zipco_referred_at!
         else
-          order.update_attributes(zipco_referred_at: nil)
+          order.update(zipco_referred_at: nil)
         end
 
         order.user_id = user.try(:id)

--- a/app/services/workarea/zipco/setup.rb
+++ b/app/services/workarea/zipco/setup.rb
@@ -20,7 +20,7 @@ module Workarea
 
         payment.set_zipco(token: create_order_response.zipco_order_id)
 
-        order.update_attributes!(zipco_order_id: create_order_response.zipco_order_id)
+        order.update!(zipco_order_id: create_order_response.zipco_order_id)
       end
 
       def redirect_uri

--- a/test/integration/workarea/storefront/zipco_integration_test.rb
+++ b/test/integration/workarea/storefront/zipco_integration_test.rb
@@ -95,7 +95,7 @@ module Workarea
       def test_cancel_removes_zipco
         payment = Payment.find(order.id)
 
-        order.update_attributes(zipco_order_id: '1234')
+        order.update(zipco_order_id: '1234')
 
         payment.set_zipco(token: '1234')
 
@@ -112,7 +112,7 @@ module Workarea
       def test_decline_removes_zipco
         payment = Payment.find(order.id)
 
-        order.update_attributes(zipco_order_id: '1234')
+        order.update(zipco_order_id: '1234')
 
         payment.set_zipco(token: '1234')
 

--- a/test/services/workarea/zipco/order_test.rb
+++ b/test/services/workarea/zipco/order_test.rb
@@ -9,7 +9,7 @@ module Workarea
         payment = Workarea::Payment.find(order.id)
 
         payment = Workarea::Payment.find(order.id)
-        payment.profile.update_attributes!(store_credit: 2.00)
+        payment.profile.update!(store_credit: 2.00)
         payment.set_store_credit
         payment.tenders.first.amount = 2.to_m
         payment.save

--- a/workarea-zipco.gemspec
+++ b/workarea-zipco.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split("\n")
 
   spec.add_dependency 'workarea', '>= 3.4.x'
+spec.required_ruby_version = ['>= 2.7', '< 3.5']
 end


### PR DESCRIPTION
## Summary
Ruby 3.2+ compatibility updates for this plugin.

### Changes
- Updated gemspec: `required_ruby_version = ['>= 2.7', '< 3.5']`
- Replaced deprecated API calls (update_attributes → update, etc.) if found
- Fixed any Ruby 3.x keyword argument incompatibilities if found

## Client impact
None — backward compatible changes only.

## Verification
Gemspec constraints verified. Common deprecated pattern replacements applied.